### PR TITLE
外部APIを追加

### DIFF
--- a/app/app/Http/Controllers/Api/PlaygroundController.php
+++ b/app/app/Http/Controllers/Api/PlaygroundController.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * 自由な実験的なコードを書くためのコントローラ
+ */
+class PlaygroundController extends Controller
+{
+    /**
+     * サンプルAPI
+     */
+    public function sample(): JsonResponse
+    {
+        return response()->json(['message' => 'This is a sample API response.']);
+    }
+}

--- a/app/bootstrap/app.php
+++ b/app/bootstrap/app.php
@@ -7,12 +7,13 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',      // 外部APIのために手動追加
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        // 必要に応じてミドルウェアを追加
     })
     ->withExceptions(function (Exceptions $exceptions) {
-        //
+        // 必要に応じて例外ハンドリングを追加
     })->create();

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,0 +1,11 @@
+<?php
+
+use App\Http\Controllers\Api\PlaygroundController;
+use Illuminate\Support\Facades\Route;
+
+// ルート定義
+Route::get('/hello', function () {
+    return response()->json(['message' => 'Hello API!']);
+});
+
+Route::get('/playground/sample', [PlaygroundController::class, 'sample']);

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -14,7 +14,6 @@ docker, Laravelコマンドのチートシート
 |:---:|:---:|
 | ルーティングを確認 | `php artisan route:list` |
 
-
 # Laravel(拡張ライブラリ)
 | 項目 | コマンド |
 |:---:|:---:|


### PR DESCRIPTION
## 概要
Playground APIを追加しました。

## 変更内容
- `/api/省略` エンドポイント作成
- 簡易なメソッド(自由な実験的なコード)のレスポンスを返却するController追加

## 動作確認
- `curl http://localhost/api/playground/sample` でJSONレスポンスが返ることを確認