### PR TITLE
Feature/add continue level example

### DIFF
--- a/app/app/Http/Controllers/Api/PlaygroundController.php
+++ b/app/app/Http/Controllers/Api/PlaygroundController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Responses\TotalResponse;
 use Illuminate\Http\JsonResponse;
 
 /**
@@ -16,5 +17,53 @@ class PlaygroundController extends Controller
     public function sample(): JsonResponse
     {
         return response()->json(['message' => 'This is a sample API response.']);
+    }
+
+    /**
+     * 作成日：2025/03/27
+     * テーマ：continue に数値を指定することで、どのループに戻るかを制御できる
+     * パターン：バグのあるコード例
+     * 処理：３はスキップして合計値を計算する予定だが、continue に数値を指定していないため、foreach ループを抜けずに処理が継続されてしまう
+     */
+    public function buggyContinueLevelExample(): TotalResponse
+    {
+        $total = 0;
+        $numberArray = [1, 2, 3, 4];
+        foreach ($numberArray as $number) {
+            switch ($number) {
+                case 3:
+                    // ↓を有効にするとPHPの構文エラーになり、「500 Internal Server Error」が返却される
+                    // PHP 7.2以前は構文エラーにはならない。 7.4以降は構文エラーになる
+                    // continue; // ここでforeachを抜けるはずが、処理が継続された。
+                default:
+                    break;
+            }
+            $total += $number; // $numberが"3"のときも加算されてしまう
+        }
+
+        return new TotalResponse($total);
+    }
+
+    /**
+     * 作成日：2025/03/27
+     * テーマ：「continue に数値を指定することで、どのループに戻るかを制御できる」
+     * パターン：正しいコード例
+     * 処理：３はスキップして合計値を計算する予定であるため、continue に数値を指定して外側のループ（foreach）に戻るように修正した
+     */
+    public function correctContinueLevelExample(): TotalResponse
+    {
+        $total = 0;
+        $numberArray = [1, 2, 3, 4];
+        foreach ($numberArray as $number) {
+            switch ($number) {
+                case 3:
+                    continue 2; // 外側のループ（foreach）に戻ります。
+                default:
+                    break;
+            }
+            $total += $number;
+        }
+
+        return new TotalResponse($total);
     }
 }

--- a/app/app/Http/Responses/TotalResponse.php
+++ b/app/app/Http/Responses/TotalResponse.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Responses;
+
+use Illuminate\Http\JsonResponse;
+
+class TotalResponse extends JsonResponse
+{
+    /**
+     * TotalResponse コンストラクタ
+     *
+     * @param  int  $total  合計値
+     * @param  int  $status  HTTPステータスコード
+     * @param  array  $headers  HTTPヘッダー
+     * @param  int  $options  JSONエンコードオプション
+     */
+    public function __construct(int $total, int $status = 200, array $headers = [], int $options = 0)
+    {
+        $data = ['total' => $total];
+        parent::__construct($data, $status, $headers, $options);
+    }
+}

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -4,8 +4,8 @@ use App\Http\Controllers\Api\PlaygroundController;
 use Illuminate\Support\Facades\Route;
 
 // ルート定義
-Route::get('/hello', function () {
-    return response()->json(['message' => 'Hello API!']);
+Route::prefix('playground')->controller(PlaygroundController::class)->group(function () {
+    Route::get('/sample', 'sample');
+    Route::get('/buggy-continue-level-example', 'buggyContinueLevelExample');
+    Route::get('/correct-continue-level-example', 'correctContinueLevelExample');
 });
-
-Route::get('/playground/sample', [PlaygroundController::class, 'sample']);

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -9,12 +9,18 @@ docker, Laravelコマンドのチートシート
 | コンテナ停止 | `docker compose stop` |
 | コンテナ(Laravel)に入る | `docker exec -it the21st_app bash` |
 
-# Laravel
+# Laravel(基本)
 | 項目 | コマンド |
 |:---:|:---:|
 | ルーティングを確認 | `php artisan route:list` |
+| 設定キャッシュ削除 | `php artisan config:clear` |
+| ルートキャッシュ削除 | `php artisan route:clear` |
+| Bladeテンプレートのキャッシュ削除 | `php artisan view:clear` |
+| アプリケーションキャッシュ削除 | `php artisan cache:clear` |
+| すべてのキャッシュをまとめて削除 | `php artisan optimize:clear` |
 
 # Laravel(拡張ライブラリ)
 | 項目 | コマンド |
 |:---:|:---:|
 | コード解析 | `vendor/bin/phpstan analyse --memory-limit=1G` |
+| コード整形 | `vendor/bin/pint` |


### PR DESCRIPTION
## 概要
APIを２つ追加しました。

## 変更内容
- `/correct-continue-level-example` APIを追加
- `/buggy-continue-level-example` APIを追加

## 動作確認
以下でJSONレスポンスが返ることを確認
- `curl http://localhost/api/correct-continue-level-example` 
- `curl http://localhost/api/buggy-continue-level-example` 