### PR TITLE
Add N+1 problem demo APIs for detection verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ The 21st Century は、Laravelを使用して構築されたWebアプリケー�
 <!-- - APIエンドポイント一覧は `docs/api.md` を参照 -->
 OpenAIドキュメント:http://localhost:8088/api/documentation  
 
+## サンプルデータベースのテーマ
+本プロジェクトのサンプルデータベースは、飲食店（レストラン）をテーマにしています。
+
+**テーブル構成：**
+- **shops（店舗）**: レストランなどの飲食店情報
+- **menus（メニュー）**: 各店舗のメニュー情報
+- **categories（カテゴリー）**: メニューのカテゴリ情報（ドリンク、フード、デザートなど）
+
+- リレーション:
+  - 1つの店舗（shops）は複数のメニュー（menus）を持つ（1対多）
+  - 1つのメニュー（menus）は1つのカテゴリー（categories）に属する（多対1）
+
+このテーマを使用して、N+1問題の検証やその他の学習目的に活用しています。
+
 ## 開発ルール
 - ブランチ運用ルール
   - `main`: 本番用
@@ -45,6 +59,10 @@ OpenAIドキュメント:http://localhost:8088/api/documentation
   - `[refactor]` コード整理（機能変更なし）
   - `[test]` テスト追加・修正
   - `[chore]` メンテナンス（ライブラリ更新など）
+
+
+
+
 ## ライセンス
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 

--- a/app/app/Http/Controllers/Api/NPlusOneController.php
+++ b/app/app/Http/Controllers/Api/NPlusOneController.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Models\Category;
+use App\Models\Shop;
+use App\Models\Menu;
+use Illuminate\Http\JsonResponse;
+
+/**
+ * @OA\Tag(
+ *     name="N+1問題検証",
+ *     description="N+1問題を意図的に発生させて検証するためのコントローラ（飲食店テーマ）"
+ * )
+ */
+class NPlusOneController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/api/n-plus-one/buggy",
+     *     summary="N+1問題が発生するAPI（バグのあるコード）",
+     *     description="Eager Loadingを使わずにリレーションを取得するため、N+1問題が発生します。
+     *     Laravel Query Detector（beyondcode/laravel-query-detector）ライブラリで検出されます。",
+     *     tags={"N+1問題検証"},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="成功時のレスポンス",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="N+1問題が発生しています"),
+     *             @OA\Property(property="shops", type="array", @OA\Items(type="object"))
+     *         )
+     *     )
+     * )
+     *
+     * 作成日：2025/03/27
+     * テーマ：N+1問題の検証（飲食店テーマ）
+     * パターン：バグのあるコード例
+     * 処理：Eager Loadingを使わずに、ループ内でリレーションを取得しているため、N+1問題が発生する
+     */
+    public function buggy(): JsonResponse
+    {
+        // 店舗を取得（1クエリ）
+        $shops = Shop::all();
+
+        // 各店舗のメニューを取得（Nクエリ）← N+1問題が発生
+        // さらに各メニューのカテゴリーを取得（N×Mクエリ）← より深刻なN+1問題
+        $result = [];
+
+        foreach ($shops as $shop) {
+            $menus = [];
+
+            foreach ($shop->menus as $menu) { // ここでN+1問題が発生（メニューごとにcategoryリレーションの遅延ロード）
+                $menus[] = [
+                    'id' => $menu->id,
+                    'name' => $menu->name,
+                    'description' => $menu->description,
+                    'price' => $menu->price,
+                    'category' => $menu->category->name, // ここでN+1問題が発生（カテゴリーごとにnameを取得）
+                ];
+            }
+
+            $result[] = [
+                'id' => $shop->id,
+                'name' => $shop->name,
+                'description' => $shop->description,
+                'address' => $shop->address,
+                'menus' => $menus,
+            ];
+        }
+
+        return response()->json([
+            'message' => 'N+1問題が発生しています。Query Detectorで検出されるはずです。',
+            'shops' => $result,
+        ]);
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/n-plus-one/correct",
+     *     summary="N+1問題を解決したAPI（正しいコード）",
+     *     description="Eager Loadingを使用してリレーションを事前に取得するため、N+1問題は発生しません。",
+     *     tags={"N+1問題検証"},
+     *
+     *     @OA\Response(
+     *         response=200,
+     *         description="成功時のレスポンス",
+     *
+     *         @OA\JsonContent(
+     *
+     *             @OA\Property(property="message", type="string", example="N+1問題は発生していません"),
+     *             @OA\Property(property="shops", type="array", @OA\Items(type="object"))
+     *         )
+     *     )
+     * )
+     *
+     * 作成日：2025/03/27
+     * テーマ：N+1問題の検証（飲食店テーマ）
+     * パターン：正しいコード例
+     * 処理：Eager Loading（with）を使用してリレーションを事前に取得するため、N+1問題は発生しない
+     */
+    public function correct(): JsonResponse
+    {
+        // Eager Loadingを使用して店舗、メニュー、カテゴリーを一度に取得（3クエリのみ）
+        $shops = Shop::with('menus.category')->get();
+
+        $result = [];
+        foreach ($shops as $shop) {
+
+            // 事前ロードの検証
+            if (! $shop->relationLoaded('menus')) {
+                throw new \RuntimeException('menusリレーションが事前ロードされていません');
+            }
+
+            $menus = [];
+            foreach ($shop->menus as $menu) {
+
+                // カテゴリーリレーションの事前ロードを検証
+                if (! $menu->relationLoaded('category')) {
+                    throw new \RuntimeException('categoryリレーションが事前ロードされていません');
+                }
+
+                $menus[] = [
+                    'id' => $menu->id,
+                    'name' => $menu->name,
+                    'description' => $menu->description,
+                    'price' => $menu->price,
+                    'category' => $menu->category->name, // 事前にロードされているため追加クエリなし
+                ];
+            }
+
+            $result[] = [
+                'id' => $shop->id,
+                'name' => $shop->name,
+                'description' => $shop->description,
+                'address' => $shop->address,
+                'menus' => $menus,
+            ];
+        }
+
+        return response()->json([
+            'message' => 'N+1問題は発生していません。Eager Loadingを使用しています。',
+            'shops' => $result,
+        ]);
+    }
+}

--- a/app/app/Http/Controllers/Api/NPlusOneController.php
+++ b/app/app/Http/Controllers/Api/NPlusOneController.php
@@ -3,9 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
-use App\Models\Category;
 use App\Models\Shop;
-use App\Models\Menu;
 use Illuminate\Http\JsonResponse;
 
 /**

--- a/app/app/Http/Controllers/Api/OpenApiInfo.php
+++ b/app/app/Http/Controllers/Api/OpenApiInfo.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+/**
+ * OpenAPI仕様の基本情報を定義するクラス
+ *
+ * このクラスはSwaggerアノテーション用のみで、実装は不要です。
+ * "@OA\Info()"はOpenAPI仕様全体で1つだけ許可されているため、
+ * このファイルに集約しています。
+ *
+ * @OA\Info(
+ *     title="The 21st Century API",
+ *     version="1.0.0",
+ *     description="The 21st Century API Documentation"
+ * )
+ */
+class OpenApiInfo
+{
+    // このクラスはアノテーション用のみで、実装は不要
+}

--- a/app/app/Http/Controllers/Api/PlaygroundController.php
+++ b/app/app/Http/Controllers/Api/PlaygroundController.php
@@ -7,9 +7,8 @@ use App\Http\Responses\TotalResponse;
 use Illuminate\Http\JsonResponse;
 
 /**
- * @OA\Info(
- *     title="Playground API",
- *     version="1.0.0",
+ * @OA\Tag(
+ *     name="Playground",
  *     description="自由な実験的なコードを書くためのコントローラ"
  * )
  */
@@ -21,10 +20,13 @@ class PlaygroundController extends Controller
      *     summary="サンプルAPI",
      *     description="これはお試し用のサンプルAPIです。",
      *     tags={"Playground"},
+     *
      *     @OA\Response(
      *         response=200,
      *         description="成功時のレスポンス",
+     *
      *         @OA\JsonContent(
+     *
      *             @OA\Property(property="message", type="string", example="This is a sample API response.")
      *         )
      *     )

--- a/app/app/Http/Responses/TotalResponse.php
+++ b/app/app/Http/Responses/TotalResponse.php
@@ -11,7 +11,7 @@ class TotalResponse extends JsonResponse
      *
      * @param  int  $total  合計値
      * @param  int  $status  HTTPステータスコード
-     * @param  array  $headers  HTTPヘッダー
+     * @param  array<string, string|string[]>  $headers  HTTPヘッダー
      * @param  int  $options  JSONエンコードオプション
      */
     public function __construct(int $total, int $status = 200, array $headers = [], int $options = 0)

--- a/app/app/Models/Category.php
+++ b/app/app/Models/Category.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property \Illuminate\Database\Eloquent\Collection<int, Menu> $menus
+ *
+ * @use HasFactory<\database\factories\CategoryFactory>
+ */
+class Category extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+
+    /**
+     * カテゴリーに紐づくメニューを取得
+     *
+     * @phpstan-return HasMany<Menu, $this>
+     */
+    public function menus(): HasMany
+    {
+        return $this->hasMany(Menu::class);
+    }
+}

--- a/app/app/Models/Category.php
+++ b/app/app/Models/Category.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class Category extends Model
 {
+    /** @use HasFactory<\Database\Factories\CategoryFactory> */
     use HasFactory;
 
     protected $fillable = [

--- a/app/app/Models/Menu.php
+++ b/app/app/Models/Menu.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use App\Models\Category;
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $shop_id
+ * @property int $category_id
+ * @property string $name
+ * @property string $description
+ * @property int $price
+ * @property Shop $shop
+ * @property Category $category
+ *
+ * @use HasFactory<\Database\Factories\MenuFactory>
+ */
+class Menu extends Model
+{
+    /** @use HasFactory<\Database\Factories\MenuFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'shop_id',
+        'category_id',
+        'name',
+        'description',
+        'price',
+    ];
+
+    /**
+     * メニューに紐づく店舗を取得
+     *
+     * @return BelongsTo<Shop, static>
+     * @phpstan-ignore-next-line
+     */
+    public function shop(): BelongsTo
+    {
+        return $this->belongsTo(Shop::class);
+    }
+
+    /**
+     * メニューに紐づくカテゴリーを取得
+     *
+     * @return BelongsTo<Category, static>
+     * @phpstan-ignore-next-line
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(Category::class);
+    }
+}

--- a/app/app/Models/Menu.php
+++ b/app/app/Models/Menu.php
@@ -4,8 +4,6 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use App\Models\Category;
-use App\Models\Shop;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
@@ -36,8 +34,7 @@ class Menu extends Model
     /**
      * メニューに紐づく店舗を取得
      *
-     * @return BelongsTo<Shop, static>
-     * @phpstan-ignore-next-line
+     * @phpstan-return BelongsTo<Shop, $this>
      */
     public function shop(): BelongsTo
     {
@@ -47,8 +44,7 @@ class Menu extends Model
     /**
      * メニューに紐づくカテゴリーを取得
      *
-     * @return BelongsTo<Category, static>
-     * @phpstan-ignore-next-line
+     * @phpstan-return BelongsTo<Category, $this>
      */
     public function category(): BelongsTo
     {

--- a/app/app/Models/Shop.php
+++ b/app/app/Models/Shop.php
@@ -31,8 +31,7 @@ class Shop extends Model
     /**
      * 店舗に紐づくメニューを取得
      *
-     * @return HasMany<Menu, static>
-     * @phpstan-ignore-next-line
+     * @phpstan-return HasMany<Menu, $this>
      */
     public function menus(): HasMany
     {

--- a/app/app/Models/Shop.php
+++ b/app/app/Models/Shop.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property string $name
+ * @property string $description
+ * @property string $address
+ * @property string|null $phone
+ * @property \Illuminate\Database\Eloquent\Collection<int, Menu> $menus
+ *
+ * @use HasFactory<\Database\Factories\ShopFactory>
+ */
+class Shop extends Model
+{
+    /** @use HasFactory<\Database\Factories\ShopFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'description',
+        'address',
+        'phone',
+    ];
+
+    /**
+     * 店舗に紐づくメニューを取得
+     *
+     * @return HasMany<Menu, static>
+     * @phpstan-ignore-next-line
+     */
+    public function menus(): HasMany
+    {
+        return $this->hasMany(Menu::class);
+    }
+}

--- a/app/config/querydetector.php
+++ b/app/config/querydetector.php
@@ -23,10 +23,10 @@ return [
      * 特定のモデル / リレーションを検知対象から除外したい場合に使います。
      */
     'except' => [
-        //Author::class => [
+        // Author::class => [
         //    Post::class,
         //    'posts',
-        //]
+        // ]
     ],
 
     /*
@@ -67,5 +67,5 @@ return [
     'output' => [
         // \BeyondCode\QueryDetector\Outputs\Alert::class,
         \BeyondCode\QueryDetector\Outputs\Log::class,   // logに出力
-    ]
+    ],
 ];

--- a/app/database/factories/CategoryFactory.php
+++ b/app/database/factories/CategoryFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<Category>
+     */
+    protected $model = Category::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->words(2, true),
+            'description' => fake()->sentence(),
+        ];
+    }
+}

--- a/app/database/factories/MenuFactory.php
+++ b/app/database/factories/MenuFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Menu;
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Menu>
+ */
+class MenuFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<Menu>
+     */
+    protected $model = Menu::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'shop_id' => Shop::factory(),
+            'category_id' => Category::factory(),
+            'name' => fake()->words(3, true),
+            'description' => fake()->sentence(),
+            'price' => fake()->numberBetween(100, 5000),
+        ];
+    }
+}

--- a/app/database/factories/ShopFactory.php
+++ b/app/database/factories/ShopFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Shop>
+ */
+class ShopFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<Shop>
+     */
+    protected $model = Shop::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->company(),
+            'description' => fake()->paragraph(),
+            'address' => fake()->address(),
+            'phone' => fake()->phoneNumber(),
+        ];
+    }
+}

--- a/app/database/migrations/2026_01_13_222515_create_categories_table.php
+++ b/app/database/migrations/2026_01_13_222515_create_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique(); // 例: "ドリンク", "フード", "デザート"
+            $table->text('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('categories');
+    }
+};

--- a/app/database/migrations/2026_01_13_222517_create_shops_table.php
+++ b/app/database/migrations/2026_01_13_222517_create_shops_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('shops', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('address')->nullable();
+            $table->string('phone')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('shops');
+    }
+};

--- a/app/database/migrations/2026_01_13_222522_create_menus_table.php
+++ b/app/database/migrations/2026_01_13_222522_create_menus_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('menus', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('shop_id')->constrained()->onDelete('cascade');
+            $table->foreignId('category_id')->constrained()->onDelete('restrict');
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->integer('price');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('menus');
+    }
+};

--- a/app/database/seeders/ShopSeeder.php
+++ b/app/database/seeders/ShopSeeder.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Category;
+use App\Models\Menu;
+use App\Models\Shop;
+use Illuminate\Database\Seeder;
+
+class ShopSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // カテゴリーを作成
+        $drinkCategory = Category::create([
+            'name' => 'ドリンク',
+            'description' => '各種ドリンクメニュー',
+        ]);
+
+        $foodCategory = Category::create([
+            'name' => 'フード',
+            'description' => '食事メニュー',
+        ]);
+
+        $dessertCategory = Category::create([
+            'name' => 'デザート',
+            'description' => 'デザートメニュー',
+        ]);
+
+        // 店舗とメニューを作成
+        $shops = [
+            [
+                'name' => 'The 21st Century Pub',
+                'description' => '行きつけのパブ。クラフトビールと本格的な料理が自慢です。',
+                'address' => '東京都渋谷区...',
+                'phone' => '03-1234-5678',
+                'menus' => [
+                    ['name' => 'クラフトビール', 'description' => '季節のクラフトビール', 'price' => 800, 'category_id' => $drinkCategory->id],
+                    ['name' => 'フィッシュ&チップス', 'description' => 'イギリス風の定番メニュー', 'price' => 1200, 'category_id' => $foodCategory->id],
+                    ['name' => 'シェパーズパイ', 'description' => '伝統的なイギリス料理', 'price' => 1500, 'category_id' => $foodCategory->id],
+                ],
+            ],
+            [
+                'name' => 'ビアガーデン サンセット',
+                'description' => '屋上ビアガーデン。夜景を楽しみながらビールを。',
+                'address' => '東京都新宿区...',
+                'phone' => '03-2345-6789',
+                'menus' => [
+                    ['name' => '生ビール', 'description' => 'キリンの生ビール', 'price' => 600, 'category_id' => $drinkCategory->id],
+                    ['name' => 'ハンバーガー', 'description' => 'ジューシーなハンバーガー', 'price' => 1000, 'category_id' => $foodCategory->id],
+                    ['name' => 'フライドポテト', 'description' => 'カリカリのポテト', 'price' => 500, 'category_id' => $foodCategory->id],
+                    ['name' => 'チョコレートケーキ', 'description' => '濃厚なチョコレートケーキ', 'price' => 700, 'category_id' => $dessertCategory->id],
+                ],
+            ],
+            [
+                'name' => 'イタリアンレストラン ベラ',
+                'description' => '本格的なイタリアン料理とワインを楽しめるレストラン。',
+                'address' => '東京都港区...',
+                'phone' => '03-3456-7890',
+                'menus' => [
+                    ['name' => 'ハウスワイン', 'description' => 'イタリア産のハウスワイン', 'price' => 900, 'category_id' => $drinkCategory->id],
+                    ['name' => 'マルゲリータピザ', 'description' => '本格的なナポリ風ピザ', 'price' => 1800, 'category_id' => $foodCategory->id],
+                    ['name' => 'カルボナーラ', 'description' => '濃厚なクリームパスタ', 'price' => 1600, 'category_id' => $foodCategory->id],
+                    ['name' => 'ティラミス', 'description' => '伝統的なイタリアンデザート', 'price' => 800, 'category_id' => $dessertCategory->id],
+                ],
+            ],
+        ];
+
+        foreach ($shops as $shopData) {
+            $menus = $shopData['menus'];
+            unset($shopData['menus']);
+
+            $shop = Shop::create($shopData);
+
+            foreach ($menus as $menuData) {
+                Menu::create(array_merge($menuData, ['shop_id' => $shop->id]));
+            }
+        }
+    }
+}

--- a/app/routes/api.php
+++ b/app/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\NPlusOneController;
 use App\Http\Controllers\Api\PlaygroundController;
 use Illuminate\Support\Facades\Route;
 
@@ -8,4 +9,9 @@ Route::prefix('playground')->controller(PlaygroundController::class)->group(func
     Route::get('/sample', 'sample');
     Route::get('/buggy-continue-level-example', 'buggyContinueLevelExample');
     Route::get('/correct-continue-level-example', 'correctContinueLevelExample');
+});
+
+Route::prefix('n-plus-one')->controller(NPlusOneController::class)->group(function () {
+    Route::get('/buggy', 'buggy');
+    Route::get('/correct', 'correct');
 });

--- a/app/tests/Feature/PlaygroundApiTest.php
+++ b/app/tests/Feature/PlaygroundApiTest.php
@@ -2,8 +2,6 @@
 
 namespace Tests\Feature;
 
-use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\TestCase;
 
 class PlaygroundApiTest extends TestCase

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -8,6 +8,7 @@ docker, Laravelコマンドのチートシート
 | コンテナ起動 | `docker compose up -d` |
 | コンテナ停止 | `docker compose stop` |
 | コンテナ(Laravel)に入る | `docker exec -it the21st_app bash` |
+| コンテナ(Laravel)に入る(ユーザー:www-data) | `docker exec -u www-data -it the21st_app bash` |
 
 # Laravel(基本)
 | 項目 | コマンド |
@@ -24,5 +25,12 @@ docker, Laravelコマンドのチートシート
 |:---:|:---:|
 | コード解析 | `vendor/bin/phpstan analyse --memory-limit=1G` |
 | コード整形 | `vendor/bin/pint` |
+| ログ出力   | `php artisan pail` |
 | テスト実行 | `php artisan test` |
 | テスト実行 | `./vendor/bin/phpunit tests/Feature/PlaygroundApiTest.php` |
+
+# Laravel(データベース)
+| 項目 | コマンド |
+|:---:|:---:|
+| マイグレーションを実行 | `php artisan migrate` |
+| ShopSeederを実行（飲食店のサンプルデータを作成） | `php artisan db:seed --class=ShopSeeder` |

--- a/docs/setup/larastan.md
+++ b/docs/setup/larastan.md
@@ -16,7 +16,7 @@ Docker 内の app コンテナに入って ライブラリをインストール�
 ### phpstan.neonの記述内容
 ```
 includes:
-    - vendor/composer require --dev larastan/larastan/larastan/extension.neon
+    - vendor/larastan/larastan/extension.neon
 
 parameters:
     level: 7

--- a/docs/setup/pail.md
+++ b/docs/setup/pail.md
@@ -22,4 +22,9 @@ Docker 内の app コンテナに入って ライブラリをインストール�
 
 パッケージは自動的に登録されるため、追加の設定は不要。
 
+## 実行
+`docker exec -u www-data -it the21st_app bash`  
+`php artisan pail`  
+
+
 完了。


### PR DESCRIPTION
### 概要

N+1問題の挙動を実際に確認・検証するためのデモ用APIを追加しました。
laravel-query-detector および laravel/pail による検知動作の確認を目的としています。

意図的に N+1 が発生する実装と、正しく最適化された実装の両方を用意しています。

### 変更内容

- N+1問題のデモAPIを追加
  - 正常系API（N+1が発生しない実装）
  - 異常系API（意図的にN+1が発生する実装）
- デモ用のサンプルテーブルを3つ追加
- N+1検証用のコントローラ・ルーティングを追加